### PR TITLE
Change fetch of available Rocks to always reset state

### DIFF
--- a/src/containers/RockListing/index.js
+++ b/src/containers/RockListing/index.js
@@ -14,7 +14,7 @@ export class RockListing extends Component {
       program: this.props.user.program,
       module: this.modAboveUser(this.props.user.module),
       message: "",
-      availableRocks: this.props.availableRocks
+      availableRocks: []
     };
   }
 
@@ -29,17 +29,18 @@ export class RockListing extends Component {
     try {
       const body = gql.findAvailableRocks(program, parseInt(module));
       const response = await fetchData(body);
+      setAvailableRocks(response.findAvailableRocks);
+      this.setState({ availableRocks: this.props.availableRocks });
       if (response.findAvailableRocks.length) {
-        setAvailableRocks(response.findAvailableRocks);
-        this.setState({ message: '', availableRocks: this.props.availableRocks});
+        this.setState({ message: ''});
       } else {
-        setAvailableRocks([]);
         this.setState({
           message: `Oh bummer! 😰 There are no rocks available for the ${program} program and module ${module}. Try a different program or module. 😀`
         });
       }
     } catch (error) {
       this.props.setError(error.message);
+      this.setState({ message: 'Something went wrong when trying to access the available rocks. Try again later.'})
     }
   };
 


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #34 

### Problem Addressed
When browsing the available rocks on the Rock Listing page, the most recent search that returned available rocks kept its results rendered on the page below the message saying that no available rocks could be found. (E.g., if I looked for BE mod 3 and found two people, then searched for BE mod 2 which had no available rocks, the "couldn't find any" message would be rendered but the two BE mod 3 people stayed on the page below the message.)

### Solution Implemented
The component's state was not getting reset when the length of the `availableRocks` value was zero. Because it needed to ideally be set to whatever the value was, whether an empty array or one with users, I moved that up out of the logic about the length of the returned array and reserved that for changing the message.

### Other Notes
React is confusing sometimes. 😅 Let me deal with SQL any day
