### PR TITLE
removes timeout for alert messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,7 +23,6 @@ firebase.initializeApp({
 
 const options = {
   position: positions.MIDDLE,
-  timeout: 6000,
   type: types.SUCCESS,
   transition: transitions.FADE
 }


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Concerns were raised that the timer used with Alert Messages would not give all users enough time to read message

### Problem Addressed
Removed Timer
### Solution Implemented

### Other Notes
Verified that the alert message can be closed via the keyboard for accessibility.